### PR TITLE
Adding Java 17 to the Github verification workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ 8 ]
+        java: [ 8, 17 ]
         # os: [ubuntu-latest, macos-latest]
         # java: [ 8, 11 ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Ensure that the plug-ins also is verified with Java 17.